### PR TITLE
Add plugin support

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,78 +1,36 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 
-	"github.com/krilor/gossh/apt"
-	"github.com/krilor/gossh/file"
-	"github.com/krilor/gossh/machine"
-	"github.com/krilor/gossh/rule"
 	"github.com/krilor/gossh/state"
-	"github.com/pkg/errors"
+
+	"plugin"
 )
+
+type pluginFunc func() (state.State, error)
 
 func main() {
 
-	state := state.New()
+	recipeName := flag.String("recipeName", "", "Name of the .so file")
+	flag.Parse()
+	p, err := plugin.Open(*recipeName)
 
-	// Add a machine to the state
-	m, err := machine.New("localhost", 22, "myUsername", "myPassword")
 	if err != nil {
-		fmt.Printf("could not get new machine %v: %v\n", m, err)
-		return
+		panic(err) //if recipeName is empty, this runs. Better error message can be added
 	}
-	state.AddMachine(m)
+	getState, err := p.Lookup("GetState") //always look for GetState function
+	if err != nil {
+		panic(err)
+	}
 
-	// TODO - add inventory, e.g.:
-	// state.AddInventory("./inventory.json")
+	newState, err := getState.(pluginFunc)() //typecast received function & call it
 
-	// Adding predefined rules from separate packages by using state.AddRule
-
-	// file.Exists is not a very helpful rule, it just creates a empty file if it does not exist
-	state.AddRule(file.Exists("/tmp/hello.nothing2"))
-
-	// apt.Package installs/uninstalls a apt package
-	state.AddRule(apt.Package{
-		Name:   "tree",
-		Status: apt.StatusInstalled,
-	})
-
-	// This rule does nothing useful, but just shows off the use of a simple cmd based rule
-	// This will allways run
-	state.AddRule(rule.Cmd{
-		CheckCmd:  "false",
-		EnsureCmd: "ls",
-	})
-
-	// This rule is a meta-rule used to construct other rules on the fly
-
-	// This is where it starts to get hairy. The Meta rule is used to create a custom rule on the fly.
-	// The example is quite simple and not very useful, but shows how to use commands directly on m,
-	//  as well as reusing the Ensure command of another Rule
-	filename := "somefile.txt"
-
-	state.AddRule(rule.Meta{
-		CheckFunc: func(m *machine.Machine, sudo bool) (bool, error) {
-			cmd := fmt.Sprintf("ls -1 /tmp | grep %s", filename)
-			r, err := m.Run(cmd, false)
-			if err != nil {
-				return false, errors.Wrap(err, "could not check for somefile")
-			}
-			if r.ExitStatus == 0 {
-				return true, nil
-			}
-
-			return false, nil
-		},
-		EnsureFunc: func(m *machine.Machine, sudo bool) error {
-			return file.Exists("/tmp/"+filename).Ensure(m, false)
-		},
-	})
-
-	// Instead of Apply, one could also do Plan (terraform style)
-	err = state.Apply()
-
+	//err = newState.Apply()
+	fmt.Printf("%+v", newState)
 	if err != nil {
 		fmt.Println("apply gone wrong", err)
 	}
+
 }

--- a/recipes/mysql/mysql.go
+++ b/recipes/mysql/mysql.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"github.com/krilor/gossh/apt"
+	"github.com/krilor/gossh/file"
+	"github.com/krilor/gossh/machine"
+	"github.com/krilor/gossh/rule"
+	"github.com/krilor/gossh/state"
+	"github.com/pkg/errors"
+)
+
+func GetState() (state.State, error) {
+
+	newState := state.New()
+
+	// Add a machine to the state
+
+	// TODO - add inventory, e.g.:
+	// state.AddInventory("./inventory.json")
+
+	// Adding predefined rules from separate packages by using state.AddRule
+
+	// file.Exists is not a very helpful rule, it just creates a empty file if it does not exist
+	newState.AddRule(file.Exists("/tmp/hello.nothing2"))
+
+	// apt.Package installs/uninstalls a apt package
+	newState.AddRule(apt.Package{
+		Name:   "mysql",
+		Status: apt.StatusInstalled,
+	})
+
+	// This rule does nothing useful, but just shows off the use of a simple cmd based rule
+	// This will allways run
+	newState.AddRule(rule.Cmd{
+		CheckCmd:  "false",
+		EnsureCmd: "ls",
+	})
+
+	// This rule is a meta-rule used to construct other rules on the fly
+
+	// This is where it starts to get hairy. The Meta rule is used to create a custom rule on the fly.
+	// The example is quite simple and not very useful, but shows how to use commands directly on m,
+	//  as well as reusing the Ensure command of another Rule
+	filename := "somefile.txt"
+
+	newState.AddRule(rule.Meta{
+		CheckFunc: func(m *machine.Machine, sudo bool) (bool, error) {
+			cmd := fmt.Sprintf("ls -1 /tmp | grep %s", filename)
+			r, err := m.Run(cmd, false)
+			if err != nil {
+				return false, errors.Wrap(err, "could not check for somefile")
+			}
+			if r.ExitStatus == 0 {
+				return true, nil
+			}
+
+			return false, nil
+		},
+		EnsureFunc: func(m *machine.Machine, sudo bool) error {
+			return file.Exists("/tmp/"+filename).Ensure(m, false)
+		},
+	})
+
+	return newState, nil
+}

--- a/recipes/tree/tree.go
+++ b/recipes/tree/tree.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"github.com/krilor/gossh/apt"
+	"github.com/krilor/gossh/file"
+	"github.com/krilor/gossh/machine"
+	"github.com/krilor/gossh/rule"
+	"github.com/krilor/gossh/state"
+	"github.com/pkg/errors"
+)
+
+func GetState() (state.State, error) {
+
+	newState := state.New()
+
+	// Add a machine to the state
+	m, err := machine.New("localhost", 22, "myUsername", "myPassword")
+	if err != nil {
+		fmt.Printf("could not get new machine %v: %v\n", m, err)
+		return newState, err
+	}
+	newState.AddMachine(m)
+
+	// TODO - add inventory, e.g.:
+	// state.AddInventory("./inventory.json")
+
+	// Adding predefined rules from separate packages by using state.AddRule
+
+	// file.Exists is not a very helpful rule, it just creates a empty file if it does not exist
+	newState.AddRule(file.Exists("/tmp/hello.nothing2"))
+
+	// apt.Package installs/uninstalls a apt package
+	newState.AddRule(apt.Package{
+		Name:   "tree",
+		Status: apt.StatusInstalled,
+	})
+
+	// This rule does nothing useful, but just shows off the use of a simple cmd based rule
+	// This will allways run
+	newState.AddRule(rule.Cmd{
+		CheckCmd:  "false",
+		EnsureCmd: "ls",
+	})
+
+	// This rule is a meta-rule used to construct other rules on the fly
+
+	// This is where it starts to get hairy. The Meta rule is used to create a custom rule on the fly.
+	// The example is quite simple and not very useful, but shows how to use commands directly on m,
+	//  as well as reusing the Ensure command of another Rule
+	filename := "somefile.txt"
+
+	newState.AddRule(rule.Meta{
+		CheckFunc: func(m *machine.Machine, sudo bool) (bool, error) {
+			cmd := fmt.Sprintf("ls -1 /tmp | grep %s", filename)
+			r, err := m.Run(cmd, false)
+			if err != nil {
+				return false, errors.Wrap(err, "could not check for somefile")
+			}
+			if r.ExitStatus == 0 {
+				return true, nil
+			}
+
+			return false, nil
+		},
+		EnsureFunc: func(m *machine.Machine, sudo bool) error {
+			return file.Exists("/tmp/"+filename).Ensure(m, false)
+		},
+	})
+
+	return newState, nil
+}


### PR DESCRIPTION
Hey,

So here is the PR to add plugin support. I created a folder called recipes and store different states there. To use them in the code: 
- go to one of the recipe directories and run `go build -buildmode=plugin`. This will create a .so file with the directory name. (mysql.so or tree.so)

- Gossh has a flag now for the recipeName. `./gossh -recipeName recipes/tree/tree.so`, will install that plugin to the program and print it.

- You can distribute `.so` files independently from the code (put not from OS) and just put them near your binary. 

---
Feel free to ignore the PR, it's just an exploration around your code with respect to #1 
